### PR TITLE
Fix incorrect MUX ratio

### DIFF
--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -387,7 +387,7 @@ impl Command  {
                 _ => Err(CommandError::OutOfRange),
             },
             Command::SetMuxRatio(ratio) => match ratio {
-                16..=NUM_PIXEL_ROWS => ok_command!(arg_buf, 0xCA, [ratio - 1]),
+                16..=NUM_PIXEL_ROWS => ok_command!(arg_buf, 0xCA, [ratio]),
                 _ => Err(CommandError::OutOfRange),
             },
             Command::SetCommandLock(ena) => {


### PR DESCRIPTION
`0x3f` is used as the MUX ratio here:
https://github.com/birdistheword96/ssd1322_rs/blob/72271eb23e108c0aac732b4e5f1fdb300abebac3/src/lib.rs#L188

but the actual value sent to the display is `0x3f - 1`:
https://github.com/birdistheword96/ssd1322_rs/blob/72271eb23e108c0aac732b4e5f1fdb300abebac3/src/instruction.rs#L390

This results in only 63 lines being usable instead of 64.

Additionally, despite the rest of this crate being ready for display sizes other than 256x64, the hardcoded mux ratio limits the crate to only displays with 64 rows.